### PR TITLE
Tweaks for syncing debug counters

### DIFF
--- a/hdl/modules/bpm_cores_pkg.vhd
+++ b/hdl/modules/bpm_cores_pkg.vhd
@@ -835,6 +835,11 @@ package bpm_cores_pkg is
         sync_trig_slow_i  : in std_logic;
 
         -----------------------------
+        -- Trigger for resetting counters (all rates)
+        -----------------------------
+        sync_counters_i   : in std_logic;
+
+        -----------------------------
         -- Debug signals
         -----------------------------
 
@@ -1071,6 +1076,11 @@ package bpm_cores_pkg is
         -----------------------------
 
         sync_trig_slow_i  : in std_logic;
+
+        -----------------------------
+        -- Trigger for resetting counters (all rates)
+        -----------------------------
+        sync_counters_i   : in std_logic;
 
         -----------------------------
         -- Debug signals

--- a/hdl/modules/wb_position_calc/wb_position_calc_core.vhd
+++ b/hdl/modules/wb_position_calc/wb_position_calc_core.vhd
@@ -268,6 +268,11 @@ port
   sync_trig_slow_i                          : in std_logic;
 
   -----------------------------
+  -- Trigger for resetting counters (all rates)
+  -----------------------------
+  sync_counters_i                           : in std_logic;
+
+  -----------------------------
   -- Debug signals
   -----------------------------
 
@@ -1932,7 +1937,7 @@ begin
   )
   port map
   (
-    rst_n_i                                 => fs_rst_n_i,
+    rst_n_i                                 => fs_rst_n_i and not sync_counters_i,
     clk_i                                   => fs_clk_i,
 
     ---------------------------------
@@ -1958,22 +1963,22 @@ begin
     c_counters_monit_amp_idx   => monit_amp_ce,
     c_counters_monit_pos_idx   => monit_pos_ce);
 
-  -- Don't wait on the actual valid from the DSP rates.
-  -- Just assume every test word is valid, which it is.
+  -- Increment counters on CICs' valids.
+  -- This is useful for checking CICs syncing.
   cnt_up_array                              <= (
-    c_counters_mix_idx        => '1',
-    c_counters_tbt_decim_idx  => '1',
-    c_counters_tbt_amp_idx    => '1',
-    c_counters_tbt_pha_idx    => '1',
-    c_counters_tbt_pos_idx    => '1',
-    c_counters_fofb_decim_idx => '1',
-    c_counters_fofb_amp_idx   => '1',
-    c_counters_fofb_pha_idx   => '1',
-    c_counters_fofb_pos_idx   => '1',
-    c_counters_monit1_amp_idx => '1',
-    c_counters_monit1_pos_idx => '1',
-    c_counters_monit_amp_idx  => '1',
-    c_counters_monit_pos_idx  => '1');
+    c_counters_mix_idx        => mix_valid,
+    c_counters_tbt_decim_idx  => tbt_decim_valid,
+    c_counters_tbt_amp_idx    => tbt_amp_valid,
+    c_counters_tbt_pha_idx    => tbt_pha_valid,
+    c_counters_tbt_pos_idx    => tbt_pos_valid,
+    c_counters_fofb_decim_idx => fofb_decim_valid,
+    c_counters_fofb_amp_idx   => fofb_amp_valid,
+    c_counters_fofb_pha_idx   => fofb_pha_valid,
+    c_counters_fofb_pos_idx   => fofb_pos_valid,
+    c_counters_monit1_amp_idx => monit1_amp_valid,
+    c_counters_monit1_pos_idx => monit1_pos_valid,
+    c_counters_monit_amp_idx  => monit_amp_valid,
+    c_counters_monit_pos_idx  => monit_pos_valid);
 
   --------------------------------------------------------------------------
   --    CDC position data (Amplitudes and Position) to fs_clk domain      --

--- a/hdl/modules/wb_position_calc/xwb_position_calc_core.vhd
+++ b/hdl/modules/wb_position_calc/xwb_position_calc_core.vhd
@@ -257,6 +257,7 @@ port
   -----------------------------
 
   sync_trig_slow_i                          : in std_logic;
+  sync_counters_i                           : in std_logic;
 
   -----------------------------
   -- Debug signals
@@ -502,6 +503,11 @@ begin
     -----------------------------
 
     sync_trig_slow_i                        => sync_trig_slow_i,
+
+    -----------------------------
+    -- Trigger for resetting counters (all rates)
+    -----------------------------
+    sync_counters_i                         => sync_counters_i,
 
     -----------------------------
     -- Debug signals

--- a/hdl/top/afc_v3/dbe_bpm_gen/dbe_bpm_gen.vhd
+++ b/hdl/top/afc_v3/dbe_bpm_gen/dbe_bpm_gen.vhd
@@ -3160,6 +3160,11 @@ begin
     sync_trig_slow_i                        => trig_pulse_rcv(c_TRIG_MUX_0_ID, c_PHASE_SYNC_TRIGGER_SLOW_ID).pulse,
 
     -----------------------------
+    -- Trigger for resetting counters (all rates)
+    -----------------------------
+    sync_counters_i                         => trig_pulse_rcv(c_TRIG_MUX_0_ID, c_DUMMY0_ID).pulse,
+
+    -----------------------------
     -- Debug signals
     -----------------------------
 
@@ -3387,6 +3392,11 @@ begin
     -----------------------------
 
     sync_trig_slow_i                        => trig_pulse_rcv(c_TRIG_MUX_1_ID, c_PHASE_SYNC_TRIGGER_SLOW_ID).pulse,
+
+    -----------------------------
+    -- Trigger for resetting counters (all rates)
+    -----------------------------
+    sync_counters_i                         => trig_pulse_rcv(c_TRIG_MUX_1_ID, c_DUMMY0_ID).pulse,
 
     -----------------------------
     -- Debug signals


### PR DESCRIPTION
Count CICs' valids instead of clock enables and add machinery for syncing (zeroing) counters. The logical trigger c_DUMMY0_ID (3) is connected to the counters syncing signal.

These changes are useful for checking CICs syncing across all BPMs.