### PR TITLE
DSPs-to-DCC CDC FIFOs 1-sample delay bug fix

### DIFF
--- a/hdl/top/afc_v3/dbe_bpm_gen/dbe_bpm_gen.vhd
+++ b/hdl/top/afc_v3/dbe_bpm_gen/dbe_bpm_gen.vhd
@@ -3829,7 +3829,7 @@ begin
 
       -- Read clock
       rd_clk_i                                  => fs_ref_clk,
-      rd_rst_n_i                                => fs_ref_rstn,
+      rd_rst_n_i                                => dsp_fofb_pos_rstn,
 
       rd_data_o                                 => dsp1_fofb_pos_xy_out_fifo_slv,
       rd_valid_o                                => dsp1_fofb_pos_valid_out_fifo,
@@ -3865,7 +3865,7 @@ begin
 
       -- Read clock
       rd_clk_i                                  => fs_ref_clk,
-      rd_rst_n_i                                => fs_ref_rstn,
+      rd_rst_n_i                                => dsp_fofb_pos_rstn,
 
       rd_data_o                                 => dsp2_fofb_pos_xy_out_fifo_slv,
       rd_valid_o                                => dsp2_fofb_pos_valid_out_fifo,


### PR DESCRIPTION
The FWFT logic of DSPs-to-DCC CDC FIFOs should be resetted along with FIFO itself when DCC is disabled. Otherwise, if FIFO is resetted and the "word that has fallen through" isn't consumed yet, a 1-sample delay bug is inserted into that FIFO until a new FPGA configuration is done.