### PR TITLE
Relax FMC constraints

### DIFF
--- a/hdl/syn/afc_v3/dbe_common/dbe_bpm2.xdc
+++ b/hdl/syn/afc_v3/dbe_common/dbe_bpm2.xdc
@@ -847,24 +847,24 @@ set clk_pll_ddr_period_less                        [expr $clk_pll_ddr_period - 1
 set clk_125mhz_period                             [get_property PERIOD [get_clocks clk_125mhz]]
 
 # real jitter is about 22ps peak-to-peak
-create_clock -period 4.300 -name fmc1_adc_clk0_p_i [get_ports fmc1_adc_clk0_p_i]
+create_clock -period 4.500 -name fmc1_adc_clk0_p_i [get_ports fmc1_adc_clk0_p_i]
 set_input_jitter fmc1_adc_clk0_p_i 0.050
-create_clock -period 4.300 -name fmc2_adc_clk0_p_i [get_ports fmc2_adc_clk0_p_i]
+create_clock -period 4.500 -name fmc2_adc_clk0_p_i [get_ports fmc2_adc_clk0_p_i]
 set_input_jitter fmc2_adc_clk0_p_i 0.050
 
-create_clock -period 4.300 -name fmc1_adc_clk1_p_i [get_ports fmc1_adc_clk1_p_i]
+create_clock -period 4.500 -name fmc1_adc_clk1_p_i [get_ports fmc1_adc_clk1_p_i]
 set_input_jitter fmc1_adc_clk1_p_i 0.050
-create_clock -period 4.300 -name fmc2_adc_clk1_p_i [get_ports fmc2_adc_clk1_p_i]
+create_clock -period 4.500 -name fmc2_adc_clk1_p_i [get_ports fmc2_adc_clk1_p_i]
 set_input_jitter fmc2_adc_clk1_p_i 0.050
 
-create_clock -period 4.300 -name fmc1_adc_clk2_p_i [get_ports fmc1_adc_clk2_p_i]
+create_clock -period 4.500 -name fmc1_adc_clk2_p_i [get_ports fmc1_adc_clk2_p_i]
 set_input_jitter fmc1_adc_clk2_p_i 0.050
-create_clock -period 4.300 -name fmc2_adc_clk2_p_i [get_ports fmc2_adc_clk2_p_i]
+create_clock -period 4.500 -name fmc2_adc_clk2_p_i [get_ports fmc2_adc_clk2_p_i]
 set_input_jitter fmc2_adc_clk2_p_i 0.050
 
-create_clock -period 4.300 -name fmc1_adc_clk3_p_i [get_ports fmc1_adc_clk3_p_i]
+create_clock -period 4.500 -name fmc1_adc_clk3_p_i [get_ports fmc1_adc_clk3_p_i]
 set_input_jitter fmc1_adc_clk3_p_i 0.050
-create_clock -period 4.300 -name fmc2_adc_clk3_p_i [get_ports fmc2_adc_clk3_p_i]
+create_clock -period 4.500 -name fmc2_adc_clk3_p_i [get_ports fmc2_adc_clk3_p_i]
 set_input_jitter fmc2_adc_clk3_p_i 0.050
 
 # ADC generated clocks


### PR DESCRIPTION
The maximum FMC ADC clock for our use case is 220.9 MHz (4.52 ns). To improve timing closure prospects, increase the clock period from 4.3 ns to 4.5 ns.