### PR TITLE
position_calc: make fixed-point position read-only.

### DIFF
--- a/hdl/modules/wb_position_calc/cheby/doc/wb_pos_calc_regs_wb.html
+++ b/hdl/modules/wb_position_calc/cheby/doc/wb_pos_calc_regs_wb.html
@@ -6216,7 +6216,7 @@ ADC gains fixed-point position constant
 <ul>
 <li><b>
 data
-</b>[<i>rw</i>]: fixed-point position constant value
+</b>[<i>ro</i>]: fixed-point position constant value
 </ul>
 <a name="adc_ch0_swclk_0_gain"></a>
 <h3><a name="sect_3_73">2.73. adc_ch0_swclk_0_gain</a></h3>

--- a/hdl/modules/wb_position_calc/cheby/wb_pos_calc_regs.cheby
+++ b/hdl/modules/wb_position_calc/cheby/wb_pos_calc_regs.cheby
@@ -2027,7 +2027,7 @@ memory-map:
       name: adc_gains_fixed_point_pos
       address: 0x0000011c
       width: 32
-      access: rw
+      access: ro
       description: ADC gains fixed-point position constant
       children:
       - field:

--- a/hdl/modules/wb_position_calc/cheby/wb_pos_calc_regs.h
+++ b/hdl/modules/wb_position_calc/cheby/wb_pos_calc_regs.h
@@ -679,7 +679,7 @@ struct pos_calc {
   /* [0x118]: REG (rw) BPM Y position offset parameter register */
   uint32_t offset_y;
 
-  /* [0x11c]: REG (rw) ADC gains fixed-point position constant */
+  /* [0x11c]: REG (ro) ADC gains fixed-point position constant */
   uint32_t adc_gains_fixed_point_pos;
 
   /* [0x120]: REG (rw) ADC channel 0 gain on RFFE switch state 0 (inverted) */


### PR DESCRIPTION
Reported-by: Henrique F. Simoes <henrique.simoes@lnls.br>