### PR TITLE
Improve the Vivado version parsing script

### DIFF
--- a/hdl/syn/afc_v3/dbe_bpm2_bo_sirius/build_synthesis_sdb.sh
+++ b/hdl/syn/afc_v3/dbe_bpm2_bo_sirius/build_synthesis_sdb.sh
@@ -8,7 +8,7 @@ set -u
 # Maximum of 16 chars
 SYNTH_INFO_PROJECT="bpm-gw-bo-sirius"
 SYNTH_INFO_TOOL="VIVADO"
-SYNTH_INFO_VER=$(vivado -version | head -n 1 | cut -d' ' -f2 | cut -d 'v' -f2)
+SYNTH_INFO_VER=$(vivado -version | grep 'Vivado v[0-9]\{4\}.*' -m 1 | cut -d' ' -f2 | cut -d 'v' -f2)
 
 SYNTH_INFO_COMMAND="../../gen_sdbsyn.py --project ${SYNTH_INFO_PROJECT} --tool ${SYNTH_INFO_TOOL} --ver ${SYNTH_INFO_VER}"
 

--- a/hdl/syn/afc_v3/dbe_bpm2_bo_sirius_with_dcc/build_synthesis_sdb.sh
+++ b/hdl/syn/afc_v3/dbe_bpm2_bo_sirius_with_dcc/build_synthesis_sdb.sh
@@ -8,7 +8,7 @@ set -u
 # Maximum of 16 chars
 SYNTH_INFO_PROJECT="bpm-gw-bo-sirius"
 SYNTH_INFO_TOOL="VIVADO"
-SYNTH_INFO_VER=$(vivado -version | head -n 1 | cut -d' ' -f2 | cut -d 'v' -f2)
+SYNTH_INFO_VER=$(vivado -version | grep 'Vivado v[0-9]\{4\}.*' -m 1 | cut -d' ' -f2 | cut -d 'v' -f2)
 
 SYNTH_INFO_COMMAND="../../gen_sdbsyn.py --project ${SYNTH_INFO_PROJECT} --tool ${SYNTH_INFO_TOOL} --ver ${SYNTH_INFO_VER}"
 

--- a/hdl/syn/afc_v3/dbe_bpm2_sr_sirius/build_synthesis_sdb.sh
+++ b/hdl/syn/afc_v3/dbe_bpm2_sr_sirius/build_synthesis_sdb.sh
@@ -8,7 +8,7 @@ set -u
 # Maximum of 16 chars
 SYNTH_INFO_PROJECT="bpm-gw-sr-sirius"
 SYNTH_INFO_TOOL="VIVADO"
-SYNTH_INFO_VER=$(vivado -version | head -n 1 | cut -d' ' -f2 | cut -d 'v' -f2)
+SYNTH_INFO_VER=$(vivado -version | grep 'Vivado v[0-9]\{4\}.*' -m 1 | cut -d' ' -f2 | cut -d 'v' -f2)
 
 SYNTH_INFO_COMMAND="../../gen_sdbsyn.py --project ${SYNTH_INFO_PROJECT} --tool ${SYNTH_INFO_TOOL} --ver ${SYNTH_INFO_VER}"
 

--- a/hdl/syn/afc_v3/dbe_bpm2_sr_sirius_with_dcc/build_synthesis_sdb.sh
+++ b/hdl/syn/afc_v3/dbe_bpm2_sr_sirius_with_dcc/build_synthesis_sdb.sh
@@ -8,7 +8,7 @@ set -u
 # Maximum of 16 chars
 SYNTH_INFO_PROJECT="bpm-gw-sr-sirius"
 SYNTH_INFO_TOOL="VIVADO"
-SYNTH_INFO_VER=$(vivado -version | head -n 1 | cut -d' ' -f2 | cut -d 'v' -f2)
+SYNTH_INFO_VER=$(vivado -version | grep 'Vivado v[0-9]\{4\}.*' -m 1 | cut -d' ' -f2 | cut -d 'v' -f2)
 
 SYNTH_INFO_COMMAND="../../gen_sdbsyn.py --project ${SYNTH_INFO_PROJECT} --tool ${SYNTH_INFO_TOOL} --ver ${SYNTH_INFO_VER}"
 

--- a/hdl/syn/afc_v3/dbe_pbpm/build_synthesis_sdb.sh
+++ b/hdl/syn/afc_v3/dbe_pbpm/build_synthesis_sdb.sh
@@ -7,7 +7,7 @@ set -u
 
 SYNTH_INFO_PROJECT="pbpm-gw"
 SYNTH_INFO_TOOL="VIVADO"
-SYNTH_INFO_VER=$(vivado -version | head -n 1 | cut -d' ' -f2 | cut -d 'v' -f2)
+SYNTH_INFO_VER=$(vivado -version | grep 'Vivado v[0-9]\{4\}.*' -m 1 | cut -d' ' -f2 | cut -d 'v' -f2)
 
 SYNTH_INFO_COMMAND="../../gen_sdbsyn.py --project ${SYNTH_INFO_PROJECT} --tool ${SYNTH_INFO_TOOL} --ver ${SYNTH_INFO_VER}"
 

--- a/hdl/syn/afc_v3/dbe_pbpm_with_dcc/build_synthesis_sdb.sh
+++ b/hdl/syn/afc_v3/dbe_pbpm_with_dcc/build_synthesis_sdb.sh
@@ -7,7 +7,7 @@ set -u
 
 SYNTH_INFO_PROJECT="pbpm-gw"
 SYNTH_INFO_TOOL="VIVADO"
-SYNTH_INFO_VER=$(vivado -version | head -n 1 | cut -d' ' -f2 | cut -d 'v' -f2)
+SYNTH_INFO_VER=$(vivado -version | grep 'Vivado v[0-9]\{4\}.*' -m 1 | cut -d' ' -f2 | cut -d 'v' -f2)
 
 SYNTH_INFO_COMMAND="../../gen_sdbsyn.py --project ${SYNTH_INFO_PROJECT} --tool ${SYNTH_INFO_TOOL} --ver ${SYNTH_INFO_VER}"
 


### PR DESCRIPTION
Use patern matching after invoking 'vivado -version'. On some conditions, Vivado prints warnings to stdout, breaking the synthesis descriptor generator.